### PR TITLE
Optimize load-store hazard detection

### DIFF
--- a/src/diad.v
+++ b/src/diad.v
@@ -150,6 +150,7 @@ module diad(
     wire [`HBIT_IMMSR:0]  w_immsr_val;
     wire [`HBIT_CC:0]     w_cc;
     wire                  w_has_src_gp;
+    wire                  w_has_tgt_gp;
     wire [`HBIT_TGT_GP:0] w_tgt_gp;
     wire                  w_tgt_gp_we;
     wire                  w_has_src_sr;
@@ -172,6 +173,7 @@ module diad(
         .ow_immsr_val (w_immsr_val),
         .ow_cc        (w_cc),
         .ow_has_src_gp(w_has_src_gp),
+        .ow_has_tgt_gp(w_has_tgt_gp),
         .ow_tgt_gp    (w_tgt_gp),
         .ow_tgt_gp_we (w_tgt_gp_we),
         .ow_has_src_sr(w_has_src_sr),
@@ -251,6 +253,11 @@ module diad(
         .iw_clk           (iw_clk),
         .iw_rst           (iw_rst),
         .iw_idex_opc      (w_opc),
+        .iw_has_src_gp    (w_has_src_gp),
+        .iw_src_gp        (w_src_gp),
+        .iw_has_tgt_gp    (w_has_tgt_gp),
+        .iw_tgt_gp        (w_tgt_gp),
+        .iw_tgt_gp_we     (w_tgt_gp_we),
         .ow_stall         (w_stall)
     );
 

--- a/src/hazard.v
+++ b/src/hazard.v
@@ -5,19 +5,44 @@ module hazard(
     input wire                  iw_clk,
     input wire                  iw_rst,
     input wire [`HBIT_OPC:0]    iw_idex_opc,
+    input wire                  iw_has_src_gp,
+    input wire [`HBIT_SRC_GP:0] iw_src_gp,
+    input wire                  iw_has_tgt_gp,
+    input wire [`HBIT_TGT_GP:0] iw_tgt_gp,
+    input wire                  iw_tgt_gp_we,
     output wire                 ow_stall
 );
-    reg [2:0] r_cnt;
-    wire hazard = (iw_idex_opc == `OPC_RU_LDu || iw_idex_opc == `OPC_SR_SRLDu);
+    reg [`HBIT_TGT_GP:0] r_ld_gp [1:0];
+    reg [1:0] r_ld_valid;
+    wire new_load = (iw_idex_opc == `OPC_RU_LDu);
+
     always @(posedge iw_clk or posedge iw_rst) begin
         if (iw_rst) begin
-            r_cnt <= 3'b000;
-        end else if (r_cnt != 3'b000) begin
-            r_cnt <= r_cnt - 3'b001;
-        end else if (hazard) begin
-            // $display("HAZARD: Hazard detected, stalling for 3 cycles");
-            r_cnt <= 3'b011;
+            r_ld_valid <= 2'b00;
+            r_ld_gp[0] <= `SIZE_TGT_GP'b0;
+            r_ld_gp[1] <= `SIZE_TGT_GP'b0;
+        end else begin
+            r_ld_valid <= {r_ld_valid[0], new_load};
+            r_ld_gp[1] <= r_ld_gp[0];
+            r_ld_gp[0] <= new_load ? iw_tgt_gp : `SIZE_TGT_GP'b0;
         end
     end
-    assign ow_stall = (r_cnt != 3'b000);
+
+    wire uses_tgt_as_src =
+        iw_has_tgt_gp &&
+        ((!iw_tgt_gp_we) ||
+         !((iw_idex_opc == `OPC_RU_MOVu) ||
+           (iw_idex_opc == `OPC_RU_LDu) ||
+           (iw_idex_opc == `OPC_IU_MOViu) ||
+           (iw_idex_opc == `OPC_IS_MOVis)));
+
+    wire hazard_src = iw_has_src_gp &&
+        ((r_ld_valid[0] && (iw_src_gp == r_ld_gp[0])) ||
+         (r_ld_valid[1] && (iw_src_gp == r_ld_gp[1])));
+
+    wire hazard_tgt = uses_tgt_as_src &&
+        ((r_ld_valid[0] && (iw_tgt_gp == r_ld_gp[0])) ||
+         (r_ld_valid[1] && (iw_tgt_gp == r_ld_gp[1])));
+
+    assign ow_stall = hazard_src || hazard_tgt;
 endmodule

--- a/src/stg3id.v
+++ b/src/stg3id.v
@@ -15,6 +15,7 @@ module stg_id(
     output wire [`HBIT_IMMSR:0]  ow_immsr_val,
     output wire [`HBIT_CC:0]     ow_cc,
     output wire                  ow_has_src_gp,
+    output wire                  ow_has_tgt_gp,
     output wire [`HBIT_TGT_GP:0] ow_tgt_gp,
     output wire                  ow_tgt_gp_we,
     output wire                  ow_has_src_sr,
@@ -111,6 +112,7 @@ module stg_id(
     reg [`HBIT_IMMSR:0]  r_immsr_val_latch;
     reg [`HBIT_CC:0]     r_cc_latch;
     reg                  r_has_src_gp_latch;
+    reg                  r_has_tgt_gp_latch;
     reg [`HBIT_TGT_GP:0] r_tgt_gp_latch;
     reg                  r_tgt_gp_we_latch;
     reg                  r_has_src_sr_latch;
@@ -130,6 +132,7 @@ module stg_id(
             r_immsr_val_latch  <= `SIZE_IMMSR'b0;
             r_cc_latch         <= `SIZE_CC'b0;
             r_has_src_gp_latch <= 1'b0;
+            r_has_tgt_gp_latch <= 1'b0;
             r_tgt_gp_latch     <= `SIZE_TGT_GP'b0;
             r_tgt_gp_we_latch  <= 1'b0;
             r_has_src_sr_latch <= 1'b0;
@@ -147,6 +150,7 @@ module stg_id(
             r_immsr_val_latch  <= `SIZE_IMMSR'b0;
             r_cc_latch         <= `SIZE_CC'b0;
             r_has_src_gp_latch <= 1'b0;
+            r_has_tgt_gp_latch <= 1'b0;
             r_tgt_gp_latch     <= `SIZE_TGT_GP'b0;
             r_tgt_gp_we_latch  <= 1'b0;
             r_has_src_sr_latch <= 1'b0;
@@ -164,6 +168,7 @@ module stg_id(
             r_immsr_val_latch  <= r_immsr_val_latch;
             r_cc_latch         <= r_cc_latch;
             r_has_src_gp_latch <= r_has_src_gp_latch;
+            r_has_tgt_gp_latch <= r_has_tgt_gp_latch;
             r_tgt_gp_latch     <= r_tgt_gp_latch;
             r_tgt_gp_we_latch  <= r_tgt_gp_we_latch;
             r_has_src_sr_latch <= r_has_src_sr_latch;
@@ -181,6 +186,7 @@ module stg_id(
             r_immsr_val_latch  <= w_immsr_val;
             r_cc_latch         <= w_cc;
             r_has_src_gp_latch <= w_has_src_gp;
+            r_has_tgt_gp_latch <= w_has_tgt_gp;
             r_tgt_gp_latch     <= w_tgt_gp;
             r_tgt_gp_we_latch  <= w_tgt_gp_we;
             r_has_src_sr_latch <= w_has_src_sr;
@@ -200,6 +206,7 @@ module stg_id(
     assign ow_immsr_val  = r_immsr_val_latch;
     assign ow_cc         = r_cc_latch;
     assign ow_has_src_gp = r_has_src_gp_latch;
+    assign ow_has_tgt_gp = r_has_tgt_gp_latch;
     assign ow_tgt_gp     = r_tgt_gp_latch;
     assign ow_tgt_gp_we  = r_tgt_gp_we_latch;
     assign ow_has_src_sr = r_has_src_sr_latch;


### PR DESCRIPTION
## Summary
- track pending load targets and only stall when subsequent instructions use them
- expose decoded target register usage to hazard logic
- wire new hazard inputs through top-level core

## Testing
- `tst/bash/test.bash LDu`
- `tst/bash/test.bash subr1`
- `tst/bash/test.bash MOVu`


------
https://chatgpt.com/codex/tasks/task_e_6895b7ffdcf4832f8b57d05e3ad2e013